### PR TITLE
Fixed .gitignore & path issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 gofresh
 *.swp
+*.exe

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 )
@@ -135,6 +136,11 @@ func GOPATH() string {
 	path := os.Getenv("GOPATH")
 	colonDelim := func(r rune) bool {
 		return r == ':'
+	}
+	if runtime.GOOS == "windows" {
+		colonDelim = func(r rune) bool {
+			return r == ';'
+		}
 	}
 	fields := strings.FieldsFunc(path, colonDelim)
 	return fields[0]


### PR DESCRIPTION
1. Add .EXE to gitignore
2. More importantly, added runtime OS detection, which changes what the path seperator to prevent the program for trying to find go path at 'C'
